### PR TITLE
Add `header("access-control-allow-origin: *");`

### DIFF
--- a/root/www/api/index.php
+++ b/root/www/api/index.php
@@ -1,5 +1,6 @@
 <?php
 	header('Content-Type: application/json');
+	header("access-control-allow-origin: *");
 	error_reporting(0);
 	require_once('auth.php');
 


### PR DESCRIPTION
Without this header, a browser refuses to receive AJAX responses to a host different from its own host. (e. g. frontend on `localhost:4200`, backend on `localhost:8000`).

Ideally, this should only be enabled in development.